### PR TITLE
fix: enable release workflow triggering from auto-created tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,8 +121,17 @@ jobs:
         echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
     
     - name: Create and push tag
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git tag ${{ steps.version.outputs.version }}
         git push origin ${{ steps.version.outputs.version }}
+    
+    - name: Trigger release workflow
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Triggering release workflow for tag ${{ steps.version.outputs.version }}"
+        gh workflow run release.yml -f tag=${{ steps.version.outputs.version }} || echo "Release workflow dispatch failed - user will need to create release manually"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to create release for'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,7 +22,12 @@ jobs:
     steps:
     - name: Get version
       id: get_version
-      run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "tag_name=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+        else
+          echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        fi
 
   build-and-package:
     needs: get-version


### PR DESCRIPTION
Problem: Auto-created tags don't trigger the release workflow due to GitHub's security restriction where GITHUB_TOKEN-created events don't trigger workflows.

Solution:
1. Added workflow_dispatch trigger to release.yml with tag input parameter
2. Modified get-version job to handle both push and dispatch events
3. Updated build workflow to dispatch release workflow after creating tag
4. Added proper error handling with fallback messaging

Now when a PR is merged to main:
1. Auto-tagging creates the version tag
2. Build workflow dispatches release workflow with the tag
3. Release workflow runs and creates GitHub release with binaries
