### PR TITLE
fix: integrate release creation directly into build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,8 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -129,9 +131,71 @@ jobs:
         git tag ${{ steps.version.outputs.version }}
         git push origin ${{ steps.version.outputs.version }}
     
-    - name: Trigger release workflow
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [test, build, tag]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        # Pull the latest tags including the one just created
+        ref: main
+    
+    - name: Pull latest tags
+      run: git fetch --tags
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+    
+    - name: Download dependencies
+      run: go mod download
+    
+    # Build binaries for release
+    - name: Build all release binaries
+      run: |
+        mkdir -p release-assets
+        
+        # Build for all platforms
+        platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
+        
+        for platform in "${platforms[@]}"; do
+          os=$(echo $platform | cut -d'/' -f1)
+          arch=$(echo $platform | cut -d'/' -f2)
+          
+          if [ "$os" = "windows" ]; then
+            suffix="-windows-$arch.exe"
+          else
+            suffix="-$os-$arch"
+          fi
+          
+          echo "Building for $os/$arch..."
+          GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build \
+            -ldflags "-s -w -X main.version=${{ needs.tag.outputs.version }}" \
+            -o "release-assets/spotify-shuffle$suffix" .
+          
+          # Create checksum
+          cd release-assets
+          if [ "$os" = "darwin" ]; then
+            shasum -a 256 "spotify-shuffle$suffix" > "spotify-shuffle$suffix.sha256"
+          else
+            sha256sum "spotify-shuffle$suffix" > "spotify-shuffle$suffix.sha256"
+          fi
+          cd ..
+        done
+    
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ needs.tag.outputs.version }}
+        name: Release ${{ needs.tag.outputs.version }}
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+        files: release-assets/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        echo "Triggering release workflow for tag ${{ steps.version.outputs.version }}"
-        gh workflow run release.yml -f tag=${{ steps.version.outputs.version }} || echo "Release workflow dispatch failed - user will need to create release manually"


### PR DESCRIPTION
Instead of trying to trigger the separate release workflow (which has permission limitations), added a complete release creation job to the build workflow that runs after auto-tagging.

New create-release job:
- Runs after test, build, and tag jobs complete
- Builds all platform binaries (Linux, macOS, Windows x amd64/arm64)
- Generates SHA256 checksums for all binaries
- Creates GitHub release using softprops/action-gh-release@v1
- Uses the tag created by the tag job
- Generates automatic release notes from commits/PRs

This ensures that when a PR is merged to main:
1. Tests pass ✅
2. Builds succeed ✅
3. Version tag is created ✅
4. GitHub release is created with all binaries ✅

No more missing releases - everything happens in one workflow\!

🤖 Generated with [Claude Code](https://claude.ai/code)