### PR TITLE
fix: strip 'v' prefix from version for Debian package compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,9 +223,13 @@ jobs:
         cp build/spotify-shuffle${{ matrix.suffix }} packaging/deb/usr/local/bin/spotify-shuffle
         chmod +x packaging/deb/usr/local/bin/spotify-shuffle
         
+        # Strip 'v' prefix from version for Debian package
+        version="${{ needs.tag.outputs.version }}"
+        deb_version="${version#v}"
+        
         cat > packaging/deb/DEBIAN/control << EOF
         Package: spotify-shuffle
-        Version: ${{ needs.tag.outputs.version }}
+        Version: $deb_version
         Section: sound
         Priority: optional
         Architecture: ${{ matrix.goarch == 'amd64' && 'amd64' || 'arm64' }}


### PR DESCRIPTION
Debian packages require version numbers to start with a digit, but our git tags include the 'v' prefix (e.g., v0.0.5). This strips the 'v' prefix specifically for the DEB package Version field.

Fixes dpkg-deb error: 'Version' field value 'v0.0.5': version number does not start with digit