### PR TITLE
fix: remove WiX UI references that require additional extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,10 +394,6 @@ jobs:
             </ComponentGroup>
             
             <Icon Id="AppIcon.exe" SourceFile="spotify-shuffle.exe" />
-            
-            <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
-            <UIRef Id="WixUI_InstallDir" />
-            <UIRef Id="WixUI_ErrorProgressText" />
           </Product>
         </Wix>
         "@ | Out-File -FilePath packaging\msi\spotify-shuffle.wxs -Encoding utf8


### PR DESCRIPTION
The WiX UI components (WixUI_InstallDir, WixUI_ErrorProgressText) require WixUIExtension.dll which isn't included in the basic WiX toolkit we're using.

Removed these UI references to create a basic MSI installer that works with the standard WiX components. The installer will still:
- Install to Program Files
- Add to system PATH
- Create Start Menu shortcut
- Support proper uninstallation

Just uses the default Windows installer UI instead of custom WiX UI.