### PR TITLE
fix: separate WiX components to resolve ICE validation errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,14 +382,17 @@ jobs:
             
             <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
               <Component Id="MainExecutable" Guid="*">
-                <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" KeyPath="yes">
-                  <Shortcut Id="StartMenuShortcut" Directory="ApplicationProgramsFolder"
-                            Name="Spotify Shuffle" Description="CLI tool for managing Spotify playlists"
-                            WorkingDirectory="INSTALLFOLDER" Icon="AppIcon.exe" IconIndex="0" />
-                </File>
+                <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" KeyPath="yes" />
                 <Environment Id="PATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="no" Part="last" Action="set" System="yes" />
+              </Component>
+              <Component Id="StartMenuComponent" Guid="*" Directory="ApplicationProgramsFolder">
+                <Shortcut Id="StartMenuShortcut" Name="Spotify Shuffle" 
+                          Description="CLI tool for managing Spotify playlists"
+                          Target="[INSTALLFOLDER]spotify-shuffle.exe" 
+                          WorkingDirectory="INSTALLFOLDER" 
+                          Icon="AppIcon.exe" IconIndex="0" />
                 <RemoveFolder Id="CleanupProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="installed" Type="integer" Value="1" KeyPath="no" />
+                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="StartMenuShortcut" Type="integer" Value="1" KeyPath="yes" />
               </Component>
             </ComponentGroup>
             


### PR DESCRIPTION
Split the MSI components to fix WiX ICE validation errors:
- ICE43: Non-advertised shortcuts need HKCU registry KeyPath
- ICE57: Mixed per-user/per-machine data with per-machine KeyPath

Changes:
- MainExecutable component: Contains only the executable file and PATH env var
- StartMenuComponent: Contains shortcut, folder cleanup, and registry key
- Uses HKCU registry value as KeyPath for the shortcut component
- Maintains all functionality while following WiX best practices

This resolves the component validation errors while keeping:
- Program Files installation
- System PATH integration
- Start Menu shortcut
- Clean uninstallation