### PR TITLE
fix: separate batch wrapper into its own WiX component

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,9 @@ jobs:
             <ComponentGroup Id="ProductComponents">
               <Component Id="MainExecutable" Guid="*" Directory="INSTALLFOLDER">
                 <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" KeyPath="yes" />
-                <File Id="SpotifyShuffleBAT" Source="spotify-shuffle.bat" />
+              </Component>
+              <Component Id="BatchWrapper" Guid="*" Directory="INSTALLFOLDER">
+                <File Id="SpotifyShuffleBAT" Source="spotify-shuffle.bat" KeyPath="yes" />
               </Component>
               <Component Id="PathComponent" Guid="*" Directory="INSTALLFOLDER">
                 <!-- User PATH - more reliable for per-user installations -->


### PR DESCRIPTION
- Split SpotifyShuffleBAT into separate BatchWrapper component
- Each component now has single file with KeyPath
- Resolves LGHT0367 error about auto-generated GUIDs
- Components with multiple files cannot use Guid='*' unless one file is versioned and others are unversioned

WiX Components now:
- MainExecutable: spotify-shuffle.exe
- BatchWrapper: spotify-shuffle.bat
- PathComponent: Environment and Registry
- StartMenuComponent: Start Menu shortcut