### PR TITLE
fix: resolve ICE38 and ICE64 errors for per-user installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,10 +388,13 @@ jobs:
             
             <ComponentGroup Id="ProductComponents">
               <Component Id="MainExecutable" Guid="*" Directory="INSTALLFOLDER">
-                <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" KeyPath="yes" />
+                <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" />
+                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="MainExecutable" Type="string" Value="[INSTALLFOLDER]spotify-shuffle.exe" KeyPath="yes" />
+                <RemoveFolder Id="RemoveInstallFolder" Directory="INSTALLFOLDER" On="uninstall" />
               </Component>
               <Component Id="BatchWrapper" Guid="*" Directory="INSTALLFOLDER">
-                <File Id="SpotifyShuffleBAT" Source="spotify-shuffle.bat" KeyPath="yes" />
+                <File Id="SpotifyShuffleBAT" Source="spotify-shuffle.bat" />
+                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="BatchWrapper" Type="string" Value="[INSTALLFOLDER]spotify-shuffle.bat" KeyPath="yes" />
               </Component>
               <Component Id="PathComponent" Guid="*" Directory="INSTALLFOLDER">
                 <!-- User PATH - more reliable for per-user installations -->


### PR DESCRIPTION
- Change KeyPath from files to registry values for user profile components
- Add HKCU registry entries for each component as KeyPath
- Add RemoveFolder for INSTALLFOLDER to handle cleanup (ICE64)
- Components now properly configured for per-user installation:
  * MainExecutable: Uses registry KeyPath, includes RemoveFolder
  * BatchWrapper: Uses registry KeyPath
  * PathComponent: Uses registry KeyPath for environment management
  * StartMenuComponent: Already uses registry KeyPath

This resolves:
- ICE38: User profile components must use registry KeyPath
- ICE64: User profile directories must be in RemoveFile table