### PR TITLE
fix: remove unnecessary batch file wrapper and simplify components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,12 +352,6 @@ jobs:
         mkdir packaging\msi
         copy build\spotify-shuffle${{ matrix.suffix }} packaging\msi\spotify-shuffle.exe
         
-        # Create a batch file wrapper for easier access
-        @'
-        @echo off
-        "%~dp0spotify-shuffle.exe" %*
-        '@ | Out-File -FilePath packaging\msi\spotify-shuffle.bat -Encoding ascii
-        
         # Create WiX source file with enhanced metadata and proper component structure
         $version = "${{ needs.tag.outputs.version }}".TrimStart('v')
         @"
@@ -387,23 +381,13 @@ jobs:
             </Directory>
             
             <ComponentGroup Id="ProductComponents">
-              <Component Id="MainExecutableFile" Guid="12345678-1234-1234-1234-123456789001" Directory="INSTALLFOLDER">
+              <Component Id="MainExecutable" Guid="12345678-1234-1234-1234-123456789001" Directory="INSTALLFOLDER">
                 <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" KeyPath="yes" />
-              </Component>
-              <Component Id="MainExecutableReg" Guid="12345678-1234-1234-1234-123456789002" Directory="INSTALLFOLDER">
-                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="MainExecutable" Type="string" Value="[INSTALLFOLDER]spotify-shuffle.exe" KeyPath="yes" />
-                <RemoveFolder Id="RemoveInstallFolder" Directory="INSTALLFOLDER" On="uninstall" />
-              </Component>
-              <Component Id="BatchWrapperFile" Guid="12345678-1234-1234-1234-123456789003" Directory="INSTALLFOLDER">
-                <File Id="SpotifyShuffleBAT" Source="spotify-shuffle.bat" KeyPath="yes" />
-              </Component>
-              <Component Id="BatchWrapperReg" Guid="12345678-1234-1234-1234-123456789004" Directory="INSTALLFOLDER">
-                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="BatchWrapper" Type="string" Value="[INSTALLFOLDER]spotify-shuffle.bat" KeyPath="yes" />
-              </Component>
-              <Component Id="PathComponent" Guid="12345678-1234-1234-1234-123456789005" Directory="INSTALLFOLDER">
-                <!-- User PATH - more reliable for per-user installations -->
                 <Environment Id="UserPATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="yes" Part="last" Action="set" System="no" />
+              </Component>
+              <Component Id="RegistryComponent" Guid="12345678-1234-1234-1234-123456789002" Directory="INSTALLFOLDER">
                 <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="InstallPath" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />
+                <RemoveFolder Id="RemoveInstallFolder" Directory="INSTALLFOLDER" On="uninstall" />
               </Component>
               <Component Id="StartMenuComponent" Guid="*" Directory="ApplicationProgramsFolder">
                 <Shortcut Id="StartMenuShortcut" Name="Spotify Shuffle" 


### PR DESCRIPTION
- Remove spotify-shuffle.bat creation (unnecessary complexity)
- Simplify to just 3 components:
  * MainExecutable: .exe file + Environment PATH
  * RegistryComponent: Registry tracking + RemoveFolder
  * StartMenuComponent: Start Menu shortcut (unchanged)
- Single .exe file is sufficient for PATH functionality
- Eliminates WiX complexity from multiple file handling