### PR TITLE
fix: use registry KeyPath for per-user components (ICE38)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,11 +382,12 @@ jobs:
             
             <ComponentGroup Id="ProductComponents">
               <Component Id="MainExecutable" Guid="12345678-1234-1234-1234-123456789001" Directory="INSTALLFOLDER">
-                <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" KeyPath="yes" />
-                <Environment Id="UserPATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="yes" Part="last" Action="set" System="no" />
+                <File Id="SpotifyShuffleEXE" Source="spotify-shuffle.exe" />
+                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="MainExecutable" Type="string" Value="[INSTALLFOLDER]spotify-shuffle.exe" KeyPath="yes" />
               </Component>
-              <Component Id="RegistryComponent" Guid="12345678-1234-1234-1234-123456789002" Directory="INSTALLFOLDER">
-                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="InstallPath" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />
+              <Component Id="PathComponent" Guid="12345678-1234-1234-1234-123456789002" Directory="INSTALLFOLDER">
+                <Environment Id="UserPATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="yes" Part="last" Action="set" System="no" />
+                <RegistryValue Root="HKCU" Key="Software\SpotifyShuffleGo" Name="PathComponent" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />
                 <RemoveFolder Id="RemoveInstallFolder" Directory="INSTALLFOLDER" On="uninstall" />
               </Component>
               <Component Id="StartMenuComponent" Guid="*" Directory="ApplicationProgramsFolder">


### PR DESCRIPTION
- MainExecutable: File + Registry KeyPath (required for per-user)
- PathComponent: Environment + Registry KeyPath + RemoveFolder
- Both components now properly use HKCU registry as KeyPath
- This resolves ICE38 error for per-user profile installations